### PR TITLE
Joshua/77 74 user name display profile deletion

### DIFF
--- a/server/database/supabase_service.py
+++ b/server/database/supabase_service.py
@@ -182,6 +182,57 @@ class SupabaseService:
         """Get all action items for a conversation"""
         return self.client.table("action_items").select("*").eq("conversation_id", conversation_id).order("created_at", desc=False).execute()
 
+    # User account functions
+    def delete_user_account(self, user_id):
+        """
+        Delete a user account and ALL associated data including:
+        - All user meetings (and their transcriptions, summaries, conversations)
+        - All user conversations (and their messages, action items)
+        - User profile
+        - Authentication account
+
+        This performs a complete account deletion with cascading cleanup.
+
+        Note: This method uses the service role key (backend only) to execute the deletion,
+        but should only be called after verifying the user's identity via JWT token.
+        """
+        # Step 1: Get all conversations for the user
+        conversations_result = self.client.table("conversations").select("id").eq("user_id", user_id).execute()
+        conversation_ids = [conv["id"] for conv in conversations_result.data]
+
+        # Step 2: Delete all messages and action items for each conversation
+        for conversation_id in conversation_ids:
+            self.client.table("messages").delete().eq("conversation_id", conversation_id).execute()
+            self.client.table("action_items").delete().eq("conversation_id", conversation_id).execute()
+
+        # Step 3: Get all meetings for the user
+        meetings_result = self.client.table("meetings").select("id").eq("user_id", user_id).execute()
+        meeting_ids = [meeting["id"] for meeting in meetings_result.data]
+
+        # Step 4: Delete all transcriptions and summaries for each meeting
+        for meeting_id in meeting_ids:
+            self.client.table("transcriptions").delete().eq("meeting_id", meeting_id).execute()
+            self.client.table("summaries").delete().eq("meeting_id", meeting_id).execute()
+
+        # Step 5: Delete all conversations
+        self.client.table("conversations").delete().eq("user_id", user_id).execute()
+
+        # Step 6: Delete all meetings
+        self.client.table("meetings").delete().eq("user_id", user_id).execute()
+
+        # Step 7: Delete the user profile
+        self.client.table("profiles").delete().eq("id", user_id).execute()
+
+        # Step 8: Delete the authentication account (requires service role key)
+        self.client.auth.admin.delete_user(user_id)
+
+        return {
+            "success": True,
+            "deleted_user_id": user_id,
+            "deleted_conversations": len(conversation_ids),
+            "deleted_meetings": len(meeting_ids)
+        }
+
 
 def get_supabase():
     global _instance

--- a/server/main.py
+++ b/server/main.py
@@ -1378,5 +1378,78 @@ async def get_meeting_transcription(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to fetch transcription: {str(e)}")
 
+@app.delete(
+    "/account",
+    tags=["Authentication"],
+    summary="Delete User Account",
+    description="""
+**Permanently delete** your user account and ALL associated data.
+
+### ⚠️ Warning: This Action is Irreversible
+
+This endpoint completely removes:
+- ✗ Your user profile
+- ✗ All your meetings
+- ✗ All transcriptions
+- ✗ All summaries
+- ✗ All conversations and chat history
+- ✗ All messages
+- ✗ All action items
+- ✗ Your authentication account
+
+### Security
+- You can only delete your own account
+- Requires valid JWT authentication token
+- User identity is verified from the token (not from request body)
+
+### After Deletion
+- You will be logged out
+- All your data will be permanently removed
+- You can create a new account with the same email if desired
+
+### Authentication
+Requires valid Supabase JWT token. The user_id is extracted from the token to ensure you can only delete your own account.
+    """,
+    response_description="Account deletion confirmation with statistics"
+)
+async def delete_account(current_user = Depends(get_current_user)):
+    """
+    Delete the authenticated user's account and all associated data.
+
+    This endpoint:
+    1. Verifies user identity via JWT token
+    2. Deletes all user data (meetings, conversations, messages, etc.)
+    3. Deletes the user profile
+    4. Deletes the authentication account
+
+    Security: User can only delete their own account. The user_id comes from
+    the verified JWT token, not from user input.
+    """
+    try:
+        user_id = current_user["id"]
+        print(f"[ACCOUNT DELETION] Starting deletion for user {user_id}")
+
+        supabase = get_supabase()
+        result = supabase.delete_user_account(user_id)
+
+        print(f"[ACCOUNT DELETION] Successfully deleted user {user_id}")
+        print(f"[ACCOUNT DELETION] - Conversations deleted: {result['deleted_conversations']}")
+        print(f"[ACCOUNT DELETION] - Meetings deleted: {result['deleted_meetings']}")
+
+        return {
+            "success": True,
+            "message": "Account successfully deleted",
+            "details": result
+        }
+    except Exception as e:
+        import traceback
+        error_trace = traceback.format_exc()
+        print(f"[ACCOUNT DELETION ERROR] Failed to delete account: {str(e)}")
+        print(f"[ACCOUNT DELETION ERROR] Traceback:\n{error_trace}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to delete account: {str(e)}"
+        )
+
 if __name__ == "__main__":
     uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/sumurai/components/Header.tsx
+++ b/sumurai/components/Header.tsx
@@ -13,7 +13,7 @@ interface HeaderProps {
 
 export default function Header({ showAuthDialog, onAuthDialogChange }: HeaderProps = {}) {
   const router = useRouter();
-  const { user, session, loading: authLoading, login, register, logout } = useAuth();
+  const { user, session, profile, loading: authLoading, login, register, logout } = useAuth();
   const [loginOpen, setLoginOpen] = useState(false);
   const [isRegister, setIsRegister] = useState(false);
   const [formData, setFormData] = useState({ email: '', password: '', confirmPassword: '' });
@@ -144,9 +144,11 @@ export default function Header({ showAuthDialog, onAuthDialogChange }: HeaderPro
               <div className="w-8 h-8 border-2 border-[#00F5FF] border-t-transparent rounded-full animate-spin"></div>
             ) : user && session ? (
               <>
-                <span className="text-white text-sm">
-                  Welcome, {user.email}
-                </span>
+                {profile && (
+                  <span className="text-white text-sm">
+                    Welcome, {profile.name || profile.first_name || user.email?.split('@')[0]}
+                  </span>
+                )}
                 <Button
                   onClick={() => router.push('/profiling')}
                   variant="outline"

--- a/sumurai/components/profile-page/components/delete-account-dialog.tsx
+++ b/sumurai/components/profile-page/components/delete-account-dialog.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Trash2, AlertTriangle } from "lucide-react";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/lib/context/auth-context";
+import { useToast } from "@/hooks/use-toast";
+
+export default function DeleteAccountDialog() {
+  const [open, setOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const { logout } = useAuth();
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const handleDeleteAccount = async () => {
+    try {
+      setIsDeleting(true);
+
+      // Get the API URL from environment variable
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+      // Get the user's session token
+      const { data: { session } } = await (await import("@/lib/services/supabase")).supabase.auth.getSession();
+
+      if (!session?.access_token) {
+        throw new Error("No authentication token found");
+      }
+
+      // Call the delete account API endpoint
+      const response = await fetch(`${apiUrl}/account`, {
+        method: "DELETE",
+        headers: {
+          "Authorization": `Bearer ${session.access_token}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || "Failed to delete account");
+      }
+
+      // Show success message
+      toast({
+        title: "Account deleted",
+        description: "Your account and all associated data have been permanently deleted.",
+      });
+
+      // Log out the user
+      await logout();
+
+      // Redirect to home page
+      router.push("/");
+
+    } catch (error) {
+      console.error("Failed to delete account:", error);
+      toast({
+        title: "Error",
+        description: error instanceof Error ? error.message : "Failed to delete account. Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsDeleting(false);
+      setOpen(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="destructive">
+          <Trash2 className="mr-2 h-4 w-4" />
+          Delete Account
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+            <AlertTriangle className="h-6 w-6 text-destructive" />
+          </div>
+          <DialogTitle className="text-center text-destructive">
+            Delete Account
+          </DialogTitle>
+          <DialogDescription className="text-center">
+            This action cannot be undone. This will permanently delete your account and remove all your data from our servers.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div className="rounded-lg border border-destructive/50 bg-destructive/5 p-4">
+            <p className="text-sm font-medium mb-2">This will permanently delete:</p>
+            <ul className="text-sm space-y-1 text-muted-foreground">
+              <li>• Your profile information</li>
+              <li>• All your meetings and transcriptions</li>
+              <li>• All summaries and action items</li>
+              <li>• All conversations and chat history</li>
+              <li>• Your authentication account</li>
+            </ul>
+          </div>
+        </div>
+
+        <DialogFooter className="sm:justify-between">
+          <DialogClose asChild>
+            <Button type="button" variant="outline" disabled={isDeleting}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleDeleteAccount}
+            disabled={isDeleting}
+          >
+            {isDeleting ? "Deleting..." : "Delete Account"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/sumurai/components/profile-page/components/profile-content.tsx
+++ b/sumurai/components/profile-page/components/profile-content.tsx
@@ -1,4 +1,4 @@
-import { Shield, Key, Trash2 } from "lucide-react";
+import { Shield, Key } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -9,6 +9,7 @@ import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
+import DeleteAccountDialog from "./delete-account-dialog";
 
 export default function ProfileContent() {
   return (
@@ -77,10 +78,7 @@ export default function ProfileContent() {
                   Permanently delete your account and all data
                 </p>
               </div>
-              <Button variant="destructive">
-                <Trash2 className="mr-2 h-4 w-4" />
-                Delete Account
-              </Button>
+              <DeleteAccountDialog />
             </div>
           </CardContent>
         </Card>

--- a/sumurai/hooks/use-toast.ts
+++ b/sumurai/hooks/use-toast.ts
@@ -1,0 +1,26 @@
+// Simple toast implementation
+// This is a placeholder - you can replace with a proper toast library later
+
+type ToastProps = {
+  title: string;
+  description?: string;
+  variant?: "default" | "destructive";
+};
+
+export function useToast() {
+  const toast = ({ title, description, variant }: ToastProps) => {
+    // For now, we'll use console and alert
+    // You can replace this with a proper toast library like react-hot-toast or sonner
+    const message = description ? `${title}\n${description}` : title;
+
+    if (variant === "destructive") {
+      console.error(message);
+      alert(message);
+    } else {
+      console.log(message);
+      alert(message);
+    }
+  };
+
+  return { toast };
+}


### PR DESCRIPTION
**Profile Deletion:**
- Made a new component, specifically for profile deletion confirmation and awareness
- Used toast and made a hook file for alert confirmation regarding account deletion
- Chat endpoint in supabase.py for account deletion
- All user account chat history data is also deleted
**User Display Name**
- users name display within the welcome header was their email address
- now pulls from their profile display name rather then their email, uses email as failsafe if one has not been added for user